### PR TITLE
fix: Remove unnecessary LDAP query of Certificate Revocation List dur…

### DIFF
--- a/lib/zgacertsutil.js
+++ b/lib/zgacertsutil.js
@@ -505,8 +505,11 @@ z.CertsChain = class{
 
 			for(var i=0; i<_this.crls.length; i++){
 				z.log("Query crl for [" + _this.crls[i] + "]");
+				const url = _this.crls[i];
+				// A query of the Certificate Revocation List (CRL) via LDAP is unnecessary during the signing process.
+				if(url.slice(0,4)==='ldap') continue;
 				/** @type {Uint8Array} */
-				var crl = await z.urlFetch(_this.crls[i]);
+				var crl = await z.urlFetch(url);
 				if(crl){
 					crls.push(crl);
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zgapdfsigner",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zgapdfsigner",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "1.15.6",


### PR DESCRIPTION
The problem was detected when trying to sign a PDF with a certificate issued by Actalis. One of the URLs in the array is an ldap request for revoked certificates.
The LDAP request is skipped because it is not needed in the signing process (which is not supported and lead to exception).